### PR TITLE
Fix requires and file structure

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -37,7 +37,6 @@ jobs:
       run: COVER=1 bundle exec rspec
     - name: Upload coverage results
       uses: actions/upload-artifact@master
-      if: always()
       with:
         name: coverage-report
         path: coverage

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,19 +7,18 @@
 
 name: Ruby
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
+
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run on push event
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'KirIgor/csp-parser'
+
     strategy:
       matrix:
-        ruby-version: ['2.5']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0']
 
     steps:
     - uses: actions/checkout@v2
@@ -34,7 +33,7 @@ jobs:
     - name: rubocop
       run: bundle exec rubocop
     - name: run tests
-      run: COVER=1 bundle exec rspec
+      run: bundle exec rspec
     - name: Upload coverage results
       uses: actions/upload-artifact@master
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
-.idea/
-coverage/
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
 
-.rspec
-.DS_Store
+# rspec failure tracking
+.rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.3.2)
+    activesupport (6.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -34,19 +34,19 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.11.0)
+    rubocop (1.17.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.2.0, < 2.0)
+      rubocop-ast (>= 1.7.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.7.0)
       parser (>= 3.0.1.1)
-    rubocop-config-umbrellio (1.11.0.51)
-      rubocop (= 1.11.0)
+    rubocop-config-umbrellio (1.17.0.53)
+      rubocop (= 1.17.0)
       rubocop-performance (= 1.10.0)
       rubocop-rails (= 2.9.1)
       rubocop-rake (= 0.5.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,4 +88,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.17.2
+   2.2.20

--- a/lib/csp.rb
+++ b/lib/csp.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module CSP
-end

--- a/lib/csp/directive.rb
+++ b/lib/csp/directive.rb
@@ -1,12 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./directive_value/serialized_source_list"
-require_relative "./directive_value/token"
-require_relative "./directive_value/sandbox"
-require_relative "./directive_value/default"
-require_relative "./grammar"
-require_relative "./csp"
-
 class CSP::Directive
   ParseError = Class.new(StandardError)
 

--- a/lib/csp/directive_value.rb
+++ b/lib/csp/directive_value.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module CSP::DirectiveValue
+  require_relative "directive_value/base"
+  require_relative "directive_value/default"
+  require_relative "directive_value/sandbox"
+  require_relative "directive_value/source"
+  require_relative "directive_value/serialized_source_list"
+  require_relative "directive_value/token"
+
+  ParseError = Class.new(StandardError)
+  InvalidSource = Class.new(StandardError)
+end

--- a/lib/csp/directive_value/base.rb
+++ b/lib/csp/directive_value/base.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
-require_relative "./source"
-require_relative "../directive_value"
-
-class CSP::DirectiveValue::Source::Base
+class CSP::DirectiveValue::Base
   def initialize(value_str)
     @value_str = value_str
     @match = @value_str.match(regexp)
 
-    raise CSP::DirectiveValue::InvalidSource, @value_str if @match.nil?
+    raise CSP::DirectiveValue::ParseError, @value_str if @match.nil?
   end
 
   def to_s

--- a/lib/csp/directive_value/default.rb
+++ b/lib/csp/directive_value/default.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./directive_value"
-require_relative "./base"
-require_relative "../grammar"
-
 class CSP::DirectiveValue::Default < CSP::DirectiveValue::Base
   private
 

--- a/lib/csp/directive_value/sandbox.rb
+++ b/lib/csp/directive_value/sandbox.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./directive_value"
-require_relative "./base"
-require_relative "../grammar"
-
 class CSP::DirectiveValue::Sandbox < CSP::DirectiveValue::Base
   private
 

--- a/lib/csp/directive_value/serialized_source_list.rb
+++ b/lib/csp/directive_value/serialized_source_list.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "./directive_value"
-require_relative "./base"
-require_relative "../grammar"
-# rubocop:disable Lint/NonDeterministicRequireOrder, Style/StringConcatenation
-Dir[File.dirname(__FILE__) + "/source/*.rb"].each { |file| require file }
-# rubocop:enable Lint/NonDeterministicRequireOrder, Style/StringConcatenation
+require_relative "source"
 
 class CSP::DirectiveValue::SerializedSourceList < CSP::DirectiveValue::Base
   SOURCE_LIST = [

--- a/lib/csp/directive_value/source.rb
+++ b/lib/csp/directive_value/source.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module CSP::DirectiveValue::Source
+  require_relative "source/base"
+  require_relative "source/hash"
+  require_relative "source/host"
+  require_relative "source/http_host"
+  require_relative "source/keyword"
+  require_relative "source/nonce"
+  require_relative "source/none"
+  require_relative "source/scheme"
+end

--- a/lib/csp/directive_value/source/base.rb
+++ b/lib/csp/directive_value/source/base.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-require_relative "./directive_value"
-
-class CSP::DirectiveValue::Base
+class CSP::DirectiveValue::Source::Base
   def initialize(value_str)
     @value_str = value_str
     @match = @value_str.match(regexp)
 
-    raise CSP::DirectiveValue::ParseError, @value_str if @match.nil?
+    raise CSP::DirectiveValue::InvalidSource, @value_str if @match.nil?
   end
 
   def to_s

--- a/lib/csp/directive_value/source/hash.rb
+++ b/lib/csp/directive_value/source/hash.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./source"
-require_relative "./base"
-require_relative "../../grammar"
-
 class CSP::DirectiveValue::Source::Hash < CSP::DirectiveValue::Source::Base
   def algorithm
     @match[:algorithm]

--- a/lib/csp/directive_value/source/host.rb
+++ b/lib/csp/directive_value/source/host.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./source"
-require_relative "./base"
-require_relative "../../grammar"
-
 class CSP::DirectiveValue::Source::Host < CSP::DirectiveValue::Source::Base
   def scheme_part
     @match[:scheme_part]

--- a/lib/csp/directive_value/source/http_host.rb
+++ b/lib/csp/directive_value/source/http_host.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./source"
-require_relative "../../grammar"
-require_relative "./host"
-
 class CSP::DirectiveValue::Source::HttpHost < CSP::DirectiveValue::Source::Host
   private
 

--- a/lib/csp/directive_value/source/keyword.rb
+++ b/lib/csp/directive_value/source/keyword.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./source"
-require_relative "./base"
-require_relative "../../grammar"
-
 class CSP::DirectiveValue::Source::Keyword < CSP::DirectiveValue::Source::Base
   private
 

--- a/lib/csp/directive_value/source/nonce.rb
+++ b/lib/csp/directive_value/source/nonce.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./source"
-require_relative "./base"
-require_relative "../../grammar"
-
 class CSP::DirectiveValue::Source::Nonce < CSP::DirectiveValue::Source::Base
   def value
     @match[:value]

--- a/lib/csp/directive_value/source/none.rb
+++ b/lib/csp/directive_value/source/none.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./source"
-require_relative "./base"
-require_relative "../../grammar"
-
 class CSP::DirectiveValue::Source::None < CSP::DirectiveValue::Source::Base
   private
 

--- a/lib/csp/directive_value/source/scheme.rb
+++ b/lib/csp/directive_value/source/scheme.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./source"
-require_relative "./base"
-require_relative "../../grammar"
-
 class CSP::DirectiveValue::Source::Scheme < CSP::DirectiveValue::Source::Base
   private
 

--- a/lib/csp/directive_value/token.rb
+++ b/lib/csp/directive_value/token.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./directive_value"
-require_relative "./base"
-require_relative "../grammar"
-
 class CSP::DirectiveValue::Token < CSP::DirectiveValue::Base
   private
 

--- a/lib/csp/grammar.rb
+++ b/lib/csp/grammar.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./csp"
-
 class CSP::Grammar
   ASCII_WHITESPACE = "(\x09|\x0a|\x0c|\x0d|\x20)"
   OPTIONAL_ASCII_WHITESPACE = "#{ASCII_WHITESPACE}*"

--- a/lib/csp/serialized_policy.rb
+++ b/lib/csp/serialized_policy.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./csp"
-require_relative "./grammar"
-require_relative "./directive"
-
 class CSP::SerializedPolicy
   ParseError = Class.new(StandardError)
 

--- a/lib/csp_parser.rb
+++ b/lib/csp_parser.rb
@@ -1,19 +1,22 @@
 # frozen_string_literal: true
 
-require_relative "./csp"
-require_relative "./serialized_policy"
-require_relative "./directive_value/source/http_host"
+module CSP
+  require_relative "csp/directive_value"
+  require_relative "csp/directive"
+  require_relative "csp/grammar"
+  require_relative "csp/serialized_policy"
 
-class CSP::Parser
-  class << self
-    def parse(csp_policy_str)
-      CSP::SerializedPolicy.new(csp_policy_str)
-    end
+  class Parser
+    class << self
+      def parse(csp_policy_str)
+        CSP::SerializedPolicy.new(csp_policy_str)
+      end
 
-    def valid_http_host_source?(http_host_str)
-      !!CSP::DirectiveValue::Source::HttpHost.new(http_host_str)
-    rescue
-      false
+      def valid_http_host_source?(http_host_str)
+        !!CSP::DirectiveValue::Source::HttpHost.new(http_host_str)
+      rescue
+        false
+      end
     end
   end
 end

--- a/lib/directive_value/directive_value.rb
+++ b/lib/directive_value/directive_value.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-require_relative "../csp"
-
-module CSP::DirectiveValue
-  ParseError = Class.new(StandardError)
-  InvalidSource = Class.new(StandardError)
-end

--- a/lib/directive_value/source/source.rb
+++ b/lib/directive_value/source/source.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-require_relative "../directive_value"
-
-module CSP::DirectiveValue::Source
-end

--- a/spec/csp_parser_spec.rb
+++ b/spec/csp_parser_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../lib/csp_parser"
-
 describe CSP::Parser do
   it "returns serialized policy for right grammars" do
     policy = CSP::Parser.parse(

--- a/spec/directive_spec.rb
+++ b/spec/directive_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../lib/directive"
-
 describe CSP::Directive do
   it "parses when right type" do
     directive = CSP::Directive.new("media-src media1.com media2.com")

--- a/spec/directive_value/default_spec.rb
+++ b/spec/directive_value/default_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/directive_value/default"
-
 describe CSP::DirectiveValue::Default do
   it "parses right directive value" do
     sandbox = CSP::DirectiveValue::Default.new("token")

--- a/spec/directive_value/sandbox_spec.rb
+++ b/spec/directive_value/sandbox_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/directive_value/sandbox"
-
 describe CSP::DirectiveValue::Sandbox do
   it "parses right sandbox" do
     sandbox = CSP::DirectiveValue::Sandbox.new("allow-scripts")

--- a/spec/directive_value/serialized_source_list_spec.rb
+++ b/spec/directive_value/serialized_source_list_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/directive_value/serialized_source_list"
-
 describe CSP::DirectiveValue::SerializedSourceList do
   it "parses right serialized source list" do
     test_str = "'none' "\

--- a/spec/directive_value/source/hash_spec.rb
+++ b/spec/directive_value/source/hash_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../lib/directive_value/source/hash"
-
 describe CSP::DirectiveValue::Source::Hash do
   it "parses right hashes" do
     hash = CSP::DirectiveValue::Source::Hash.new(

--- a/spec/directive_value/source/host_spec.rb
+++ b/spec/directive_value/source/host_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../lib/directive_value/source/host"
-
 describe CSP::DirectiveValue::Source::Host do
   it "parses right hosts" do
     host = CSP::DirectiveValue::Source::Host.new("ftp://*.example.com:*/path")

--- a/spec/directive_value/source/http_host_spec.rb
+++ b/spec/directive_value/source/http_host_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../lib/directive_value/source/http_host"
-
 describe CSP::DirectiveValue::Source::HttpHost do
   it "parses right hosts" do
     host = CSP::DirectiveValue::Source::HttpHost.new("https://*.example.com:*/path")

--- a/spec/directive_value/source/keyword_spec.rb
+++ b/spec/directive_value/source/keyword_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../lib/directive_value/source/keyword"
-
 describe CSP::DirectiveValue::Source::Keyword do
   it "parses right keyword" do
     keyword = CSP::DirectiveValue::Source::Keyword.new("'report-sample'")

--- a/spec/directive_value/source/nonce_spec.rb
+++ b/spec/directive_value/source/nonce_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../lib/directive_value/source/nonce"
-
 describe CSP::DirectiveValue::Source::Nonce do
   it "parses right nonce" do
     nonce = CSP::DirectiveValue::Source::Nonce.new(

--- a/spec/directive_value/source/none_spec.rb
+++ b/spec/directive_value/source/none_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../lib/directive_value/source/none"
-
 describe CSP::DirectiveValue::Source::None do
   it "parses right none" do
     nonce = CSP::DirectiveValue::Source::None.new("'none'")

--- a/spec/directive_value/source/scheme_spec.rb
+++ b/spec/directive_value/source/scheme_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../lib/directive_value/source/scheme"
-
 describe CSP::DirectiveValue::Source::Scheme do
   it "parses right scheme" do
     nonce = CSP::DirectiveValue::Source::Scheme.new("example:")

--- a/spec/directive_value/token_spec.rb
+++ b/spec/directive_value/token_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/directive_value/token"
-
 describe CSP::DirectiveValue::Token do
   it "parses right token" do
     sandbox = CSP::DirectiveValue::Token.new("token")

--- a/spec/serialized_policy_spec.rb
+++ b/spec/serialized_policy_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../lib/serialized_policy"
-
 describe CSP::SerializedPolicy do
   it "parses right policy" do
     policy_str = "default-src 'self'; "\

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "simplecov"
-require "csp_parser"
 
 SimpleCov.start do
   enable_coverage :branch
@@ -14,3 +13,5 @@ SimpleCov.start do
   minimum_coverage 90
   maximum_coverage_drop 2
 end
+
+require "csp_parser"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "simplecov"
+require "csp_parser"
 
 SimpleCov.start do
   enable_coverage :branch


### PR DESCRIPTION
- Разнес реквайры по модулям и убрал дубликацию.
- Поправил структуру файлов. Теперь модуль `CSP::DirectiveValue::Source::Nonce` находится по пути `lib/csp/directive_value/source/nonce.rb`, как и положено.
- Запилил стандрартный gitignore (в старом зачем-то скипнут файл `.rspec`, из-за чего `spec_helper` по дефолту не реквайрится).
- Обновил CI. Теперь экшены гоняются в форках (например https://github.com/tycooon/csp-parser/actions). Еще добавил  новые версии руби в матрицу.
- Обновил зависимости.